### PR TITLE
:bug: hotfix MongoClient path wrong :bug:

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,14 @@
 #from typing import List
 #from uuid import UUID
 from fastapi import FastAPI, HTTPException
-#from pymongo import MongoClient
+from pymongo import MongoClient
 
 #from models.models import Gender, Role, User
 
 app = FastAPI()
 
-#client = MongoClient("mongodb://localhost:27017/")
-#db = client["GovernmentCatnip"]
+client = MongoClient(host="db")
+db = client["government_catnip"]
 
 #db: List[User] = [
 #    User(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,7 @@ version: '3.8'
 services:
   
   # Database - Mongo DB
-  database:
-    container_name: mongodb
+  db:
     image: mongo
     environment:
       MONGO_INITDB_DATABASE: government_catnip


### PR DESCRIPTION
So, @Jakarin-Jojo found that we have an issue when the program run and try to get the data from mongo in path localhost:27017
it got reject when request, so I found that when we run python in docker and want to call from itself it's not localhost but it's a container name from docker-compose.yml file so, I decide to change path from mongodb//localhost:27017 to db